### PR TITLE
Dependecy and hostname configuration update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <failsafe.plugin.version>2.22.0</failsafe.plugin.version>
         <findbugs.maven.plugin.version>3.0.5</findbugs.maven.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
-        <jacoco.maven.plugin.version>0.8.1</jacoco.maven.plugin.version>
+        <jacoco.maven.plugin.version>0.8.5</jacoco.maven.plugin.version>
         <docker.maven.plugin.version>0.26.1</docker.maven.plugin.version>
     </properties>
 

--- a/src/test/resources/test_environment_windows.json
+++ b/src/test/resources/test_environment_windows.json
@@ -1,22 +1,22 @@
 {
     "GetOrderFunction": {
-        "ENDPOINT_OVERRIDE": "http://docker.for.windows.localhost:8000",
+        "ENDPOINT_OVERRIDE": "http://host.docker.internal:8000",
         "TABLE_NAME": "orders_table"
     },
     "GetOrdersFunction": {
-        "ENDPOINT_OVERRIDE": "http://docker.for.windows.localhost:8000",
+        "ENDPOINT_OVERRIDE": "http://host.docker.internal:8000",
         "TABLE_NAME": "orders_table"
     },
     "UpdateOrderFunction": {
-        "ENDPOINT_OVERRIDE": "http://docker.for.windows.localhost:8000",
+        "ENDPOINT_OVERRIDE": "http://host.docker.internal:8000",
         "TABLE_NAME": "orders_table"
     },
     "DeleteOrderFunction": {
-        "ENDPOINT_OVERRIDE": "http://docker.for.windows.localhost:8000",
+        "ENDPOINT_OVERRIDE": "http://host.docker.internal:8000",
         "TABLE_NAME": "orders_table"
     },
     "CreateOrderFunction": {
-        "ENDPOINT_OVERRIDE": "http://docker.for.windows.localhost:8000",
+        "ENDPOINT_OVERRIDE": "http://host.docker.internal:8000",
         "TABLE_NAME": "orders_table"
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#15, #16 
*Description of changes:*

- Updated maven dependency for JaCoCo
- Updated hostname for endpoints for windows to recommended `host.docker.internal`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
