### PR TITLE
upgrade netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${aws.sdk.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>io.netty</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -143,12 +149,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.26.Final</version>
+                <version>4.1.46.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.26.Final</version>
+                <version>4.1.46.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
*Issue #, if available:*
This pull request is to resolve the security vulnerabilities in the repository. The pull request created by the bot https://github.com/aws-samples/aws-sam-java-rest/pull/19 is not sufficient as there are some transitive dependencies as well which should be excluded.

*Description of changes:*

Pom.xml : Bump netty-handler from 4.1.26.Final to 4.1.46.Final and exclude transitive dependency

* How this change was testes *
mvn test - unit test
mvn verify - integration tests
Status - successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
