### PR TITLE
upgrade netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
-        <aws.lambda.java.core.version>1.1.0</aws.lambda.java.core.version>
-        <aws.sdk.version>2.0.0-preview-11</aws.sdk.version>
+        <aws.lambda.java.core.version>1.2.1</aws.lambda.java.core.version>
+        <aws.sdk.version>2.13.39</aws.sdk.version>
         <dynamodblocal.version>1.11.119</dynamodblocal.version>
         <lombok.version>1.18.2</lombok.version>
         <dagger.version>2.16</dagger.version>
@@ -76,12 +76,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${aws.sdk.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -129,6 +123,10 @@
                 <exclusion>
                     <artifactId>ion-java</artifactId>
                     <groupId>software.amazon.ion</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -143,12 +149,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.26.Final</version>
+                <version>4.1.46.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.26.Final</version>
+                <version>4.1.46.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/test/java/com/amazonaws/handler/CreateOrderHandlerTest.java
+++ b/src/test/java/com/amazonaws/handler/CreateOrderHandlerTest.java
@@ -33,7 +33,7 @@ public class CreateOrderHandlerTest {
     public void handleRequest_whenCreateOrderInputStreamEmpty_puts400InOutputStream() throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         sut.handleRequest(new ByteArrayInputStream(new byte[0]), os, TestContext.builder().build());
-        assertTrue(os.toString().contains("Invalid JSON"));
+        assertTrue(os.toString().contains("Body was null"));
         assertTrue(os.toString().contains("400"));
     }
 

--- a/src/test/java/com/amazonaws/handler/DeleteOrderHandlerTest.java
+++ b/src/test/java/com/amazonaws/handler/DeleteOrderHandlerTest.java
@@ -33,7 +33,7 @@ public class DeleteOrderHandlerTest {
     public void handleRequest_whenDeleteOrderInputStreamEmpty_puts400InOutputStream() throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         sut.handleRequest(new ByteArrayInputStream(new byte[0]), os, TestContext.builder().build());
-        assertTrue(os.toString().contains("Invalid JSON"));
+        assertTrue(os.toString().contains("order_id was not set"));
         assertTrue(os.toString().contains("400"));
     }
 

--- a/src/test/java/com/amazonaws/handler/GetOrderHandlerTest.java
+++ b/src/test/java/com/amazonaws/handler/GetOrderHandlerTest.java
@@ -36,7 +36,7 @@ public class GetOrderHandlerTest {
     public void handleRequest_whenGetOrderInputStreamEmpty_puts400InOutputStream() throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         sut.handleRequest(new ByteArrayInputStream(new byte[0]), os, TestContext.builder().build());
-        assertTrue(os.toString().contains("Invalid JSON"));
+        assertTrue(os.toString().contains("order_id was not set"));
         assertTrue(os.toString().contains("400"));
     }
 

--- a/src/test/java/com/amazonaws/handler/UpdateOrderHandlerTest.java
+++ b/src/test/java/com/amazonaws/handler/UpdateOrderHandlerTest.java
@@ -33,7 +33,7 @@ public class UpdateOrderHandlerTest {
     public void handleRequest_whenUpdateOrderInputStreamEmpty_puts400InOutputStream() throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         sut.handleRequest(new ByteArrayInputStream(new byte[0]), os, TestContext.builder().build());
-        assertTrue(os.toString().contains("Invalid JSON"));
+        assertTrue(os.toString().contains("order_id was not set"));
         assertTrue(os.toString().contains("400"));
     }
 


### PR DESCRIPTION
*Issue #, if available:*

This pull request is to resolve the security vulnerabilities in the repository. The pull request created by the bot #19 is not sufficient as there are some transitive dependencies as well which 
should be excluded.

*Description of changes:*

Pom.xml : Bump netty-handler from 4.1.26.Final to 4.1.46.Final and exclude transitive dependency

*How this change was tested*

-  mvn test : unit test
-   mvn verify : integration tests  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
