### PR TITLE
Bump netty-codec-http from 4.1.46.Final to 4.1.59.Final and Bump junit from 4.12 to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dynamodblocal.version>1.11.119</dynamodblocal.version>
         <lombok.version>1.18.2</lombok.version>
         <dagger.version>2.16</dagger.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>[4.13.1,)</junit.version>
         <mockito.version>2.0.2-beta</mockito.version>
         <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
         <failsafe.plugin.version>2.22.0</failsafe.plugin.version>
@@ -76,6 +76,16 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -147,12 +157,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.46.Final</version>
+                <version>[4.1.59.Final,)</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.46.Final</version>
+                <version>[4.1.59.Final,)</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This commit will Bump netty-codec-http from 4.1.46.Final to 4.1.59.Final
and Bump junit from 4.12 to 4.13.1

*Issue #, if available:*
This commit will resolve the security bot alerts

*Description of changes:*

- Bump netty-codec-http from 4.1.46.Final to 4.1.59.Final
- Bump junit from 4.12 to 4.13.1

### Testing

- Unit Testing : mvn test

```
3c22fb02d7b2 % mvn test
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< com.amazonaws:aws-sam-java-rest >-------------------
[INFO] Building A sample REST application built on SAM and DynamoDB 1.0.0
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/junit/junit/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/junit/junit/maven-metadata.xml (1.3 kB at 2.8 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.1/junit-4.13.1.pom
Downloaded from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.1/junit-4.13.1.pom (25 kB at 258 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom
Downloaded from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom (27 kB at 262 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar
Downloaded from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar (385 kB at 1.4 MB/s)
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce) @ aws-sam-java-rest ---
[INFO] 
[INFO] --- maven-checkstyle-plugin:3.0.0:check (validate) @ aws-sam-java-rest ---
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.1:prepare-agent (default-prepare-agent) @ aws-sam-java-rest ---
[INFO] argLine set to -javaagent:/Users/mokhanxy/.m2/repository/org/jacoco/org.jacoco.agent/0.8.1/org.jacoco.agent-0.8.1-runtime.jar=destfile=/Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/jacoco.exec,excludes=**/*_MembersInjector.*
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ aws-sam-java-rest ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ aws-sam-java-rest ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ aws-sam-java-rest ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 4 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ aws-sam-java-rest ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ aws-sam-java-rest ---
[INFO] Surefire report directory: /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.amazonaws.handler.CreateOrderHandlerTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.518 sec
Running com.amazonaws.handler.UpdateOrderHandlerTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.056 sec
Running com.amazonaws.handler.DeleteOrderHandlerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec
Running com.amazonaws.handler.GetOrderHandlerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.051 sec
Running com.amazonaws.dao.OrderDaoTest
Tests run: 46, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.301 sec

Results :

Tests run: 65, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.478 s
[INFO] Finished at: 2021-02-19T21:01:14-08:00
[INFO] ------------------------------------------------------------------------

```

- Integration Testing : mvn verify

```
3c22fb02d7b2 % mvn verify
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< com.amazonaws:aws-sam-java-rest >-------------------
[INFO] Building A sample REST application built on SAM and DynamoDB 1.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce) @ aws-sam-java-rest ---
[INFO] 
[INFO] --- maven-checkstyle-plugin:3.0.0:check (validate) @ aws-sam-java-rest ---
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.1:prepare-agent (default-prepare-agent) @ aws-sam-java-rest ---
[INFO] argLine set to -javaagent:/Users/mokhanxy/.m2/repository/org/jacoco/org.jacoco.agent/0.8.1/org.jacoco.agent-0.8.1-runtime.jar=destfile=/Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/jacoco.exec,excludes=**/*_MembersInjector.*
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ aws-sam-java-rest ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ aws-sam-java-rest ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ aws-sam-java-rest ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 4 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ aws-sam-java-rest ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ aws-sam-java-rest ---
[INFO] Surefire report directory: /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.amazonaws.handler.CreateOrderHandlerTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.282 sec
Running com.amazonaws.handler.UpdateOrderHandlerTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.054 sec
Running com.amazonaws.handler.DeleteOrderHandlerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 sec
Running com.amazonaws.handler.GetOrderHandlerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 sec
Running com.amazonaws.dao.OrderDaoTest
Tests run: 46, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.267 sec

Results :

Tests run: 65, Failures: 0, Errors: 0, Skipped: 0

[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ aws-sam-java-rest ---
[INFO] Building jar: /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/aws-sam-java-rest-1.0.0.jar
[INFO] 
[INFO] --- maven-shade-plugin:3.1.1:shade (default) @ aws-sam-java-rest ---
[INFO] Including com.amazonaws:aws-lambda-java-core:jar:1.2.1 in the shaded jar.
[INFO] Including software.amazon.awssdk:dynamodb:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.awssdk:aws-json-protocol:jar:2.13.39 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-core:jar:2.10.4 in the shaded jar.
[INFO] Including software.amazon.awssdk:protocol-core:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.awssdk:profiles:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.awssdk:sdk-core:jar:2.13.39 in the shaded jar.
[INFO] Including org.slf4j:slf4j-api:jar:1.7.28 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-databind:jar:2.10.4 in the shaded jar.
[INFO] Including org.reactivestreams:reactive-streams:jar:1.0.2 in the shaded jar.
[INFO] Including software.amazon.awssdk:auth:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.eventstream:eventstream:jar:1.0.1 in the shaded jar.
[INFO] Including software.amazon.awssdk:http-client-spi:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.awssdk:regions:jar:2.13.39 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-annotations:jar:2.9.6 in the shaded jar.
[INFO] Including software.amazon.awssdk:annotations:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.awssdk:utils:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.awssdk:aws-core:jar:2.13.39 in the shaded jar.
[INFO] Including software.amazon.awssdk:netty-nio-client:jar:2.13.39 in the shaded jar.
[INFO] Including io.netty:netty-codec-http2:jar:4.1.46.Final in the shaded jar.
[INFO] Including io.netty:netty-codec:jar:4.1.46.Final in the shaded jar.
[INFO] Including io.netty:netty-transport:jar:4.1.46.Final in the shaded jar.
[INFO] Including io.netty:netty-resolver:jar:4.1.46.Final in the shaded jar.
[INFO] Including io.netty:netty-common:jar:4.1.46.Final in the shaded jar.
[INFO] Including io.netty:netty-buffer:jar:4.1.46.Final in the shaded jar.
[INFO] Including io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.46.Final in the shaded jar.
[INFO] Including io.netty:netty-transport-native-unix-common:jar:4.1.46.Final in the shaded jar.
[INFO] Including com.typesafe.netty:netty-reactive-streams-http:jar:2.0.4 in the shaded jar.
[INFO] Including com.typesafe.netty:netty-reactive-streams:jar:2.0.4 in the shaded jar.
[INFO] Including software.amazon.awssdk:apache-client:jar:2.13.39 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpclient:jar:4.5.9 in the shaded jar.
[INFO] Including commons-logging:commons-logging:jar:1.2 in the shaded jar.
[INFO] Including commons-codec:commons-codec:jar:1.11 in the shaded jar.
[INFO] Including org.apache.httpcomponents:httpcore:jar:4.4.10 in the shaded jar.
[INFO] Including com.google.dagger:dagger:jar:2.16 in the shaded jar.
[INFO] Including javax.inject:javax.inject:jar:1 in the shaded jar.
[INFO] Including org.projectlombok:lombok:jar:1.18.2 in the shaded jar.
[INFO] Minimizing jar com.amazonaws:aws-sam-java-rest:jar:1.0.0
[INFO] org.apache.commons.logging.LogSource not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.WeakHashtable$Entry not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.Log4JLogger not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.LogFactoryImpl$3 not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.LogFactoryImpl$2 not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.LogFactoryImpl$1 not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.LogFactoryImpl not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.Jdk13LumberjackLogger not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.WeakHashtable$1 not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.WeakHashtable$Referenced not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.NoOpLog not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.ServletContextCleaner not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.AvalonLogger not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.SimpleLog not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.WeakHashtable$WeakKey not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.SimpleLog$1 not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.Jdk14Logger not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.WeakHashtable not removed because it was specifically included
[INFO] org.apache.commons.logging.impl.LogKitLogger not removed because it was specifically included
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[INFO] Minimized 6946 -> 4352 (62%)
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/aws-sam-java-rest-1.0.0.jar with /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/aws-sam-java-rest-1.0.0-shaded.jar
[INFO] Dependency-reduced POM written at: /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/dependency-reduced-pom.xml
[INFO] 
[INFO] --- docker-maven-plugin:0.26.1:start (prepare-it-database) @ aws-sam-java-rest ---
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Start container 18ee3b7a161f
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Waiting on url http://localhost:8000/shell/ with method HEAD for status 200..399.
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Waited on url http://localhost:8000/shell/ 1806 ms
[INFO] 
[INFO] --- maven-failsafe-plugin:2.22.0:integration-test (default) @ aws-sam-java-rest ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.amazonaws.handler.CreateOrderHandlerIT
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.465 s - in com.amazonaws.handler.CreateOrderHandlerIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- docker-maven-plugin:0.26.1:stop (remove-it-database) @ aws-sam-java-rest ---
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Stop and removed container 18ee3b7a161f after 0 ms
[INFO] 
[INFO] >>> findbugs-maven-plugin:3.0.5:check (default) > :findbugs @ aws-sam-java-rest >>>
[INFO] 
[INFO] --- findbugs-maven-plugin:3.0.5:findbugs (findbugs) @ aws-sam-java-rest ---
[INFO] Fork Value is true
[INFO] Done FindBugs Analysis....
[INFO] 
[INFO] <<< findbugs-maven-plugin:3.0.5:check (default) < :findbugs @ aws-sam-java-rest <<<
[INFO] 
[INFO] 
[INFO] --- findbugs-maven-plugin:3.0.5:check (default) @ aws-sam-java-rest ---
[INFO] BugInstance size is 0
[INFO] Error size is 0
[INFO] No errors/warnings found
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.1:report (default-report) @ aws-sam-java-rest ---
[INFO] Loading execution data file /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/jacoco.exec
[INFO] Analyzed bundle 'A sample REST application built on SAM and DynamoDB' with 30 classes
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.1:check (default-check) @ aws-sam-java-rest ---
[INFO] Loading execution data file /Users/mokhanxy/Desktop/Work/git/aws-sam-java-rest/target/jacoco.exec
[INFO] Analyzed bundle 'aws-sam-java-rest' with 30 classes
[INFO] All coverage checks have been met.
[INFO] 
[INFO] --- maven-failsafe-plugin:2.22.0:verify (default) @ aws-sam-java-rest ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.599 s
[INFO] Finished at: 2021-02-19T21:03:04-08:00
[INFO] ------------------------------------------------------------------------

```
- End to End Test: python3 src/test/resources/api_tests.py 3

```
0> [~/Desktop/Work/git/aws-sam-java-rest]  
3c22fb02d7b2 % python3 src/test/resources/api_tests.py 3


TEST: CREATING ORDER
{"orderId":"3670ba98-21ce-49f9-845e-989303263092","customerId":"19","preTaxAmount":12,"postTaxAmount":11,"version":1}

Attempting to parse JSON...
{'orderId': '3670ba98-21ce-49f9-845e-989303263092', 'customerId': '19', 'preTaxAmount': 12, 'postTaxAmount': 11, 'version': 1}



TEST: CREATING ORDER
{"orderId":"5af9103c-506d-4423-a919-a1636c0bc43c","customerId":"38","preTaxAmount":36,"postTaxAmount":26,"version":1}

Attempting to parse JSON...
{'orderId': '5af9103c-506d-4423-a919-a1636c0bc43c', 'customerId': '38', 'preTaxAmount': 36, 'postTaxAmount': 26, 'version': 1}



TEST: CREATING ORDER
{"orderId":"891108be-288d-4e5f-9674-05321c0fe247","customerId":"9","preTaxAmount":30,"postTaxAmount":29,"version":1}

Attempting to parse JSON...
{'orderId': '891108be-288d-4e5f-9674-05321c0fe247', 'customerId': '9', 'preTaxAmount': 30, 'postTaxAmount': 29, 'version': 1}



TEST: GETTING ALL ORDERS
{"lastEvaluatedKey":null,"orders":[{"orderId":"891108be-288d-4e5f-9674-05321c0fe247","customerId":"9","preTaxAmount":30,"postTaxAmount":29,"version":1},{"orderId":"3670ba98-21ce-49f9-845e-989303263092","customerId":"19","preTaxAmount":12,"postTaxAmount":11,"version":1},{"orderId":"5af9103c-506d-4423-a919-a1636c0bc43c","customerId":"38","preTaxAmount":36,"postTaxAmount":26,"version":1}]}

Attempting to parse JSON...
{'lastEvaluatedKey': None, 'orders': [{'orderId': '891108be-288d-4e5f-9674-05321c0fe247', 'customerId': '9', 'preTaxAmount': 30, 'postTaxAmount': 29, 'version': 1}, {'orderId': '3670ba98-21ce-49f9-845e-989303263092', 'customerId': '19', 'preTaxAmount': 12, 'postTaxAmount': 11, 'version': 1}, {'orderId': '5af9103c-506d-4423-a919-a1636c0bc43c', 'customerId': '38', 'preTaxAmount': 36, 'postTaxAmount': 26, 'version': 1}]}



TEST: GETTING SPECIFIC ORDERS
{"orderId":"891108be-288d-4e5f-9674-05321c0fe247","customerId":"9","preTaxAmount":30,"postTaxAmount":29,"version":1}

Attempting to parse JSON...
{'orderId': '891108be-288d-4e5f-9674-05321c0fe247', 'customerId': '9', 'preTaxAmount': 30, 'postTaxAmount': 29, 'version': 1}

{"orderId":"3670ba98-21ce-49f9-845e-989303263092","customerId":"19","preTaxAmount":12,"postTaxAmount":11,"version":1}

Attempting to parse JSON...
{'orderId': '3670ba98-21ce-49f9-845e-989303263092', 'customerId': '19', 'preTaxAmount': 12, 'postTaxAmount': 11, 'version': 1}

{"orderId":"5af9103c-506d-4423-a919-a1636c0bc43c","customerId":"38","preTaxAmount":36,"postTaxAmount":26,"version":1}

Attempting to parse JSON...
{'orderId': '5af9103c-506d-4423-a919-a1636c0bc43c', 'customerId': '38', 'preTaxAmount': 36, 'postTaxAmount': 26, 'version': 1}



TEST: UPDATING SPECIFIC ORDERS
{"orderId":"891108be-288d-4e5f-9674-05321c0fe247","customerId":"5083","preTaxAmount":5207,"postTaxAmount":5088,"version":2} 200

Attempting to parse JSON...
{'orderId': '891108be-288d-4e5f-9674-05321c0fe247', 'customerId': '5083', 'preTaxAmount': 5207, 'postTaxAmount': 5088, 'version': 2}

{"orderId":"3670ba98-21ce-49f9-845e-989303263092","customerId":"5438","preTaxAmount":5692,"postTaxAmount":5662,"version":2} 200

Attempting to parse JSON...
{'orderId': '3670ba98-21ce-49f9-845e-989303263092', 'customerId': '5438', 'preTaxAmount': 5692, 'postTaxAmount': 5662, 'version': 2}

{"orderId":"5af9103c-506d-4423-a919-a1636c0bc43c","customerId":"5606","preTaxAmount":5033,"postTaxAmount":5511,"version":2} 200

Attempting to parse JSON...
{'orderId': '5af9103c-506d-4423-a919-a1636c0bc43c', 'customerId': '5606', 'preTaxAmount': 5033, 'postTaxAmount': 5511, 'version': 2}



TEST: DELETING SPECIFIC ORDERS
{"orderId":"891108be-288d-4e5f-9674-05321c0fe247","customerId":"5083","preTaxAmount":5207,"postTaxAmount":5088,"version":2}

Attempting to parse JSON...
{'orderId': '891108be-288d-4e5f-9674-05321c0fe247', 'customerId': '5083', 'preTaxAmount': 5207, 'postTaxAmount': 5088, 'version': 2}

{"orderId":"3670ba98-21ce-49f9-845e-989303263092","customerId":"5438","preTaxAmount":5692,"postTaxAmount":5662,"version":2}

Attempting to parse JSON...
{'orderId': '3670ba98-21ce-49f9-845e-989303263092', 'customerId': '5438', 'preTaxAmount': 5692, 'postTaxAmount': 5662, 'version': 2}

{"orderId":"5af9103c-506d-4423-a919-a1636c0bc43c","customerId":"5606","preTaxAmount":5033,"postTaxAmount":5511,"version":2}

Attempting to parse JSON...
{'orderId': '5af9103c-506d-4423-a919-a1636c0bc43c', 'customerId': '5606', 'preTaxAmount': 5033, 'postTaxAmount': 5511, 'version': 2}



TEST: GETTING ALL ORDERS
{"lastEvaluatedKey":null,"orders":[]}

Attempting to parse JSON...
{'lastEvaluatedKey': None, 'orders': []}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
